### PR TITLE
Added support for key rollover

### DIFF
--- a/src/customer-key-store/Models/TestStore.cs
+++ b/src/customer-key-store/Models/TestStore.cs
@@ -140,7 +140,10 @@ namespace Microsoft.InformationProtection.Web.Models
         {
             keyAuth.ThrowIfNull(nameof(keyAuth));
 
-            keys.Add(keyName, new Dictionary<string, KeyStoreData>());
+            if(!keys.ContainsKey(keyName))
+            {
+                keys.Add(keyName, new Dictionary<string, KeyStoreData>());
+            }
 
             keys[keyName][keyId] = new KeyStoreData(
                                                 new TestKey(publicKey, privateKey),


### PR DESCRIPTION
DKE supports having key rollover where the active key that is used for protection can be deprecated for a new one but still used for decryption.. This PR fixes a bug with this.