### PR TITLE
Update customerkeystore.csproj .NET 8

### DIFF
--- a/src/customer-key-store/customerkeystore.csproj
+++ b/src/customer-key-store/customerkeystore.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <RunCodeAnalysis>true</RunCodeAnalysis>
@@ -8,12 +8,11 @@
     <DocumentationFile>$(BaseIntermediateOutputPath)\$(MSBuildThisFileName).xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="3.0.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18"/>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.0"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8"/>
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.11"/>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11"/>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11"/>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.11"/>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118"/>
-    <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="3.1.6"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="8.0.1"/>
   </ItemGroup>
 </Project>

--- a/src/customer-key-store/customerkeystore.csproj
+++ b/src/customer-key-store/customerkeystore.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>$(MSBuildProjectDirectory)\CodeAnalysisRuleSet.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>$(BaseIntermediateOutputPath)\$(MSBuildThisFileName).xml</DocumentationFile>
   </PropertyGroup>


### PR DESCRIPTION
Updated customerkeystore.csproj for referencing .NET 8 instead of deprecated .NET 3.x